### PR TITLE
missing cost in CreatureOnBoard copy

### DIFF
--- a/src/main/java/com/codingame/game/engine/CreatureOnBoard.java
+++ b/src/main/java/com/codingame/game/engine/CreatureOnBoard.java
@@ -29,6 +29,7 @@ public class CreatureOnBoard
   {
     this.id = creature.id;
     this.baseId = creature.baseId;
+    this.cost = creature.cost;
     this.attack = creature.attack;
     this.defense = creature.defense;
     this.keywords = new Keywords(creature.keywords);


### PR DESCRIPTION
For a fight there are copies made of all creatures. For this copy the cost is not copied and so if a creatures survives a fight in looses the cost.
Not a game changing event, just wrong data.